### PR TITLE
Changed to different navstack reference

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -147,7 +147,7 @@ $('.browse-files').on('click', function(e) {
         context: 'overlay',
         appId: Fliplet.Env.get('appId'),
         folder: filePickerData.selectFiles[0],
-        navStack: filePickerData.selectFiles[1]
+        navStack: filePickerData.selectFiles[0].navStackRef || {}
       }
     }
   });


### PR DESCRIPTION
Because we changed the navstack reference created by the file picker in https://github.com/Fliplet/fliplet-widget-file-picker/pull/25 we needed to update the code to be able to open the file manager in the correct folder